### PR TITLE
removes duplicate destroy run command

### DIFF
--- a/run
+++ b/run
@@ -1029,22 +1029,6 @@ restart() {
     docker-compose restart
 }
 
-desc "destroy" <<HEREDOC
-Usage:
-    ${_ME} destroy
-
-Description:
-    stops and deletes docker data!!!!
-HEREDOC
-destroy() {
-    echo "THIS WILL DELETE ALL DATA IN DOCKER VOLUMES!"
-    echo "ARE YOU SURE? ctrl+c TO STOP!"
-    read -r
-    echo "ARE YOU REALLY SURE? ctrl+c TO STOP!"
-    read -r
-    docker-compose destroy -v
-}
-
 desc "gencert" <<HEREDOC
 Usage:
     ${_ME} gencert <hostname>


### PR DESCRIPTION
The command is already defined above here:
https://github.com/infonova/infocmdb/blob/develop/run#L983-L997

The first (kept) occurrence executes `docker-compose down -v --remove-orphans`
while the second (removed) command executed `docker-compose destroy -v`.