### PR TITLE
adds backup directory and files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ library/perl
 /docker/nginx/custom-conf/conf.d/ssl/*.crt
 /docker/nginx/custom-conf/conf.d/ssl/*.key
 /docker/nginx/custom-conf/conf.d/*.conf
+backup/**
+*data*.tar.gz
+*dump*.sql.gz


### PR DESCRIPTION
backup directory for all (manually moved) backups with possible sub directories
data and dump files that match the default backup names of:
* ./run mysql_backup
* ./run data_backup

I'm not sure how you feel about these possibly special .gitignore rules.
I personally like to store these close to the project, but it's no big deal if you want to keep the .gitignore file cleaner. I can always add it to my personal ignore config :)