### PR TITLE
fixes global history to lead directly to the proper ci:history entry

### DIFF
--- a/application/models/History.php
+++ b/application/models/History.php
@@ -333,7 +333,7 @@ class Dao_History extends Dao_Abstract
             ->where('date(' . Db_History::TABLE_NAME . '.' . Db_History::DATESTAMP . ") <= ?", date('Y-m-d', strtotime($endDate)) . ' 00:00:00');
 
         if ($filteredHistoryIds) {
-            $select->where(Db_History::TABLE_NAME . '.' . Db_History::ID . ' IN ' . '(' . $filteredHistoryIds . ')');
+            $select->where(Db_History::TABLE_NAME . '.' . Db_History::ID . ' IN ' . '(' . implode(',', $filteredHistoryIds) . ')');
         }
         if (is_null($filterSet) || $onlyDateFilter) {
             $select->limitPage($page, $rowcount);

--- a/application/modules/cmdb/controllers/HistoryController.php
+++ b/application/modules/cmdb/controllers/HistoryController.php
@@ -179,6 +179,11 @@ class HistoryController extends AbstractAppAction
         ### OPTIONAL PARAMS ###
         $historyId = $this->_getParam('historyId');
 
+        $filteredHistoryIds = null;
+        if(strlen($historyId) > 0){
+            $filteredHistoryIds = explode(',', $historyId);
+        }
+
         ### FILTER PARAMS ###
         $relationChanged = $this->_getParam('relationChange');
         $projectChanged  = $this->_getParam('projectChanged');
@@ -223,7 +228,7 @@ class HistoryController extends AbstractAppAction
         $historyServiceGet = new Service_History_Get($this->translator, $this->logger, parent::getUserInformation()->getThemeId());
 
         ### GET HISTORY LIST ###
-        $getHistoryListResult = $historyServiceGet->getHistoryList($historyId, $ciId, $page, $fromDate, $toDate, parent::getUserInformation()->getRoot(), parent::getUserInformation()->getId(), null, $selectedAttributeOptions, $relationChanged, $ciTypeChanged, $projectChanged, $options, $filterSet, $onlyDateFilter);
+        $getHistoryListResult = $historyServiceGet->getHistoryList($historyId, $ciId, $page, $fromDate, $toDate, parent::getUserInformation()->getRoot(), parent::getUserInformation()->getId(), $filteredHistoryIds, $selectedAttributeOptions, $relationChanged, $ciTypeChanged, $projectChanged, $options, $filterSet, $onlyDateFilter);
         $historyList          = $getHistoryListResult['historyList'];
 
         ### getAttributes from History Service ###

--- a/application/modules/cmdb/views/scripts/history/ci.phtml
+++ b/application/modules/cmdb/views/scripts/history/ci.phtml
@@ -490,8 +490,8 @@ if ($config->ci->detail->buttons->button) {
 
 
             ?>
-            <div id="history_list">
-                <div id="history_list_header">
+            <div id="history_list_<?php $history[Db_History::ID]; ?>" class="history_list">
+                <div id="history_list_header_<?php $history[Db_History::ID]; ?>" class="history_list_header">
                     <span class="left"><?php echo $restore;
                         echo $history_view; ?><strong><?php echo $history[Db_History::DATESTAMP]; ?></strong></span>
                     <span class="center"><strong><?php echo $history[Db_History::NOTE] ?></strong></span>

--- a/application/modules/cmdb/views/scripts/history/index.phtml
+++ b/application/modules/cmdb/views/scripts/history/index.phtml
@@ -52,7 +52,7 @@
             ?>
             <tr>
                 <td>
-                    <a class="link" href="<?php echo APPLICATION_URL ?>history/ci/historyId/<?php echo $item[Db_History::ID]; ?>/"><?php echo $item['ci_id']; ?></a>
+                    <a class="link" href="<?php echo APPLICATION_URL ?>/history/ci/ciid/<?php echo $item['ci_id']; ?>/historyId/<?php echo $item[Db_History::ID]; ?>"><?php echo $item['ci_id']; ?></a>
                 </td>
                 <td><?php echo $item[Db_History::DATESTAMP]; ?></td>
                 <td><?php echo $item['default_attribute'][Db_CiAttribute::VALUE_TEXT]; ?></td>

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -2184,13 +2184,13 @@ table.list span.deleted {
 }
 
 /* New History List */
-#history_list {
+.history_list {
     border: 1px solid #999999;
     display: block;
     padding-bottom: 10px;
 }
 
-#history_list_header {
+.history_list_header {
     text-align: center;
     width: 100%;
     padding-top: 2px;
@@ -2200,17 +2200,17 @@ table.list span.deleted {
     padding: 0px;
 }
 
-#history_list_header span.left {
+.history_list_header span.left {
     padding-left: 10px;
     float: left;
 }
 
-#history_list_header span.right {
+.history_list_header span.right {
     float: right;
     padding-right: 10px;
 }
 
-#history_list_header span.center {
+.history_list_header span.center {
 }
 
 #history_list_content {


### PR DESCRIPTION
fixes #50

* fixed duplicate div:id's
* fixed history links
* added proper filter when ci:history receives a historyId parameter
* historyId parameters can be comma separeted for multiple entries