### PR TITLE
fixes singleedit not being cancel able on firefox

### DIFF
--- a/application/modules/cmdb/views/scripts/ci/_singleEditIndex.phtml
+++ b/application/modules/cmdb/views/scripts/ci/_singleEditIndex.phtml
@@ -13,7 +13,8 @@
         // submit when hitting enter key
         $(document).on('keydown', function(event) {
             if (event.key === "Escape") {
-                location.reload();
+                window.location = window.location;
+                return false;
             } else if (event.key === "Enter") {
                 var refreshSuccess = refreshLock(lock_id, refresh_rate, LOCK_LANG_STRINGS);
                 invalidLocks[lock_id] = lock_id;


### PR DESCRIPTION
Replaces `location.reload()` with `window.location = window.location`
to prevent reload confirmation while displaying search/filter results.

Adds `return false;` to prevent the default action.
In firefox the default action for Escape is to cancel pending requests,
which immediately stops the triggered reload.