### PR TITLE
fixes singleedit attribute permissions query

### DIFF
--- a/application/models/Attribute.php
+++ b/application/models/Attribute.php
@@ -869,9 +869,10 @@ class Dao_Attribute extends Dao_Abstract
 
         if ($userId > 0) {
             $select->join(Db_AttributeRole::TABLE_NAME, Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::ATTRIBUTE_ID . ' = ' . Db_Attribute::TABLE_NAME . '.' . Db_Attribute::ID, array())
-                ->join(Db_UserRole::TABLE_NAME, Db_UserRole::TABLE_NAME . '.' . Db_UserRole::ROLE_ID . ' = ' . Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::ROLE_ID, array(Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::PERMISSION_WRITE))
+                ->join(Db_UserRole::TABLE_NAME, Db_UserRole::TABLE_NAME . '.' . Db_UserRole::ROLE_ID . ' = ' . Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::ROLE_ID, array(Db_AttributeRole::PERMISSION_WRITE => 'MAX(' . Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::PERMISSION_WRITE . ')'))
                 ->where(Db_UserRole::TABLE_NAME . '.' . Db_UserRole::USER_ID . '=?', $userId)
-                ->where(Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::PERMISSION_READ . ' =?', '1');
+                ->where(Db_AttributeRole::TABLE_NAME . '.' . Db_AttributeRole::PERMISSION_READ . ' =?', '1')
+                ->group(Db_Attribute::TABLE_NAME . '.' . Db_Attribute::ID);
         }
 
         $rowset = $this->db->fetchAll($select);


### PR DESCRIPTION
When a user had multiple attribute roles with conflicting write permissions
the query returned the attribute twice,
one row with write permissions and one without.
Only the last row was taken into account.

The query was rewritten to prevent this from happening.
If at least one role grants the user write permissions to an attribute
it will now take precedence.

Old query:
```sql
SELECT DISTINCT `attribute`.*, `attribute_role`.`permission_write`
FROM `attribute`
     INNER JOIN `attribute_role`
                ON attribute_role.attribute_id = attribute.id
     INNER JOIN `user_role`
                ON user_role.role_id = attribute_role.role_id
WHERE (attribute.id IN (:positionList))
  AND (attribute.is_active = '1')
  AND (user_role.user_id = :userId)
  AND (attribute_role.permission_read = '1')
```

New query:
```sql
SELECT DISTINCT `attribute`.*, MAX(attribute_role.permission_write) AS `permission_write`
FROM `attribute`
     INNER JOIN `attribute_role`
                ON attribute_role.attribute_id = attribute.id
     INNER JOIN `user_role`
                ON user_role.role_id = attribute_role.role_id
WHERE (attribute.id IN (:positionList))
  AND (attribute.is_active = '1')
  AND (user_role.user_id = :userId)
  AND (attribute_role.permission_read = '1')
GROUP BY `attribute`.`id`
```