### PR TITLE
adds .gitignore rule for `/docker/php/custom-conf/**`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ library/perl
 /docker/nginx/custom-conf/conf.d/ssl/*.crt
 /docker/nginx/custom-conf/conf.d/ssl/*.key
 /docker/nginx/custom-conf/conf.d/*.conf
+/docker/php/custom-conf/**
 backup/**
 *data*.tar.gz
 *dump*.sql.gz


### PR DESCRIPTION
This allows adding a custom xdebug.ini file.