### PR TITLE
fixes workflow context data types to be consistent

### DIFF
--- a/application/services/Ci/Get.php
+++ b/application/services/Ci/Get.php
@@ -1355,7 +1355,6 @@ class Service_Ci_Get extends Service_Abstract
 
         $projectDaoImpl   = new Dao_Project();
         $attributeDaoImpl = new Dao_Attribute();
-        $relDaoImpl       = new Dao_CiRelation();
         $ciTypeDaoImpl    = new Dao_CiType();
         $relService       = new Service_Relation_Get($this->translator, $this->logger, parent::getThemeId());
 
@@ -1366,18 +1365,22 @@ class Service_Ci_Get extends Service_Abstract
         $ci_type    = $ciTypeDaoImpl->getCiType($ci['ci_type_id']);
         $rel        = $relService->getMinimalRelationInfo($ciId);
 
-        $output = array();
-//        $old_info = $rel;
+        $output              = array();
         $output['relations'] = $rel;
-        $output['projects']  = array();
+        $output['projects']  = new stdClass();
         foreach ($projects as $project) {
-            $output['projects'][$project['id']] = $project;
+            $projectId                      = $project['id'];
+            $output['projects']->$projectId = $project;
         }
         $output['ciTypeId']   = $ci_type['id'];
         $output['ciTypeName'] = $ci_type['name'];
-        $output['attributes'] = array();
+        $output['attributes'] = new stdClass();
         foreach ($attributes as $attribute) {
-            $output['attributes'][$attribute['id']][$attribute['ciAttributeId']] = $attribute;
+            $attributeId                        = $attribute['id'];
+            $ciAttributeId                      = $attribute['ciAttributeId'];
+            $attributeObject                    = new stdClass();
+            $attributeObject->$ciAttributeId    = $attribute;
+            $output['attributes']->$attributeId = $attributeObject;
         }
         return $output;
     }

--- a/application/services/Relation/Get.php
+++ b/application/services/Relation/Get.php
@@ -206,25 +206,27 @@ class Service_Relation_Get extends Service_Abstract
 
     /**
      * @param $ciID
+     * @return stdClass relations object ready for json formatting
      */
     public function getMinimalRelationInfo($ciID)
     {
         $relDaoImpl = new Dao_CiRelation();
 
-        $info = array();
+        $relationsObject = new stdClass();
 
         $relations  = $relDaoImpl->getRelationsForCi($ciID);
         $directions = $relDaoImpl->getDirections(Db_CiRelationDirection::ID);
         foreach ($relations as $relation) {
-            $identifier                              = $relation['id'];
-            $info[$identifier]                       = array();
-            $info[$identifier]['ci_id_1']            = $relation['ci_id_1'];
-            $info[$identifier]['ci_id_2']            = $relation['ci_id_2'];
-            $info[$identifier]['relation_type_id']   = $relation['ci_relation_type_id'];
-            $info[$identifier]['direction']          = $relation['direction'];
-            $info[$identifier]['relation_type_name'] = $relDaoImpl->getRelationTypeById($relation['ci_relation_type_id'])['name'];
-            $info[$identifier]['direction_name']     = $directions[$relation['direction']]['name'];
+            $relationId                         = $relation['id'];
+            $relationObject                     = new stdClass();
+            $relationObject->ci_id_1            = $relation['ci_id_1'];
+            $relationObject->ci_id_2            = $relation['ci_id_2'];
+            $relationObject->relation_type_id   = $relation['ci_relation_type_id'];
+            $relationObject->direction          = $relation['direction'];
+            $relationObject->relation_type_name = $relDaoImpl->getRelationTypeById($relation['ci_relation_type_id'])['name'];
+            $relationObject->direction_name     = $directions[$relation['direction']]['name'];
+            $relationsObject->$relationId       = $relationObject;
         }
-        return $info;
+        return $relationsObject;
     }
 }

--- a/application/services/Relation/Get.php
+++ b/application/services/Relation/Get.php
@@ -173,8 +173,8 @@ class Service_Relation_Get extends Service_Abstract
         if (is_dir($dir)) {
             if ($dh = opendir($dir)) {
                 while (($file = readdir($dh)) !== false) {
-                    if (is_file($dir .'/'. $file) && substr($file, 0, 1) != '.') {
-                        $mod = date("Y-m-d, H:i:s", filemtime($dir .'/'. $file));
+                    if (is_file($dir . '/' . $file) && substr($file, 0, 1) != '.') {
+                        $mod = date("Y-m-d, H:i:s", filemtime($dir . '/' . $file));
                         array_push($fileList,
                             array(
                                 'name' => $file,

--- a/tests/unit/application/services/ci/CiTest.php
+++ b/tests/unit/application/services/ci/CiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+class CiTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var Service_Ci_Get
+     */
+    protected $ciServiceGet;
+
+    protected function _before()
+    {
+        $this->ciServiceGet = new Service_Ci_Get(null, null, 0);
+    }
+
+    protected function _after()
+    {
+    }
+
+    // tests
+
+    /**
+     * @covers Service_Ci_Get::getContextInfoForCi()
+     */
+    public function testGetContextInfoForCi()
+    {
+        $context = $this->ciServiceGet->getContextInfoForCi(2);
+
+        $this->assertNotEmpty($context);
+
+        $this->assertInstanceOf(stdClass::class, $context["relations"],
+            "relations should be serialized to an json object");
+        $this->assertEmpty(get_object_vars($context["relations"]),
+            "context should contain no relations");
+
+        $this->assertInstanceOf(stdClass::class, $context["projects"],
+            "projects should be serialized to an json object");
+        $this->assertNotEmpty(get_object_vars($context["projects"]),
+            "context should contain projects");
+
+        $this->assertInstanceOf(stdClass::class, $context["attributes"],
+            "attributes should be serialized to an json object");
+        $this->assertNotEmpty(get_object_vars($context["attributes"]),
+            "context should contain attributes");
+    }
+
+}


### PR DESCRIPTION
Previously most workflow context data types were either an empty array if no data was present
or an object otherwise.
This affected relations, projects and attributes,
although the bug occurred mostly with relations (they are the most likely to be empty).

All of these have been fixed by replacing the array data type with a stdClass,
which will always serialize to a json object even if empty.