### PR TITLE
Fix types of identifiers in script workflow params

### DIFF
--- a/application/utils/Executable.php
+++ b/application/utils/Executable.php
@@ -63,10 +63,10 @@ class Util_Executable
         $this->logger->log($logMessage, Zend_Log::INFO);
 
         $workflowContext = array(
-            "ciid"          => $ciId,
-            "userId"        => $user->getId(),
-            "ciAttributeId" => $ciAttributeId,
-            "attributeId"   => $attributeId,
+            "ciid"          => (int) $ciId,
+            "userId"        => (int) $user->getId(),
+            "ciAttributeId" => (int) $ciAttributeId,
+            "attributeId"   => (int) $attributeId,
             "triggerType"   => $triggerType,
         );
 


### PR DESCRIPTION
Changes types of ciid, userId, ciAttributeId and attributeId workflow parameters
in scripts/executables from string to int.

Previous example:
```json
{
  "apikey": "...",
  "ciid": "11373",
  "userId": "10",
  "ciAttributeId": "179301",
  "attributeId": "77",
  "triggerType": "executable",
  "user_id": "10",
  "workflow_item_id": 35152,
  "workflow_instance_id": 35152
}
```

New example:
```json
{
  "apikey": "...",
  "ciid": 11373,
  "userId": 10,
  "ciAttributeId": 179301,
  "attributeId": 77,
  "triggerType": "executable",
  "user_id": "10",
  "workflow_item_id": 35152,
  "workflow_instance_id": 35152
}
```